### PR TITLE
Fix Airflow-Ext Dependency

### DIFF
--- a/plugins/plugins.meltano.yml
+++ b/plugins/plugins.meltano.yml
@@ -33,7 +33,7 @@ plugins:
   utilities:
   - name: airflow
     variant: apache
-    pip_url: git+https://github.com/meltano/airflow-ext.git@main apache-airflow==2.7.0 psycopg2-binary
+    pip_url: git+https://github.com/meltano/airflow-ext.git@811287a6c2e7dc74498c26ef5f830e9df78dc976 apache-airflow==2.7.0 psycopg2-binary
       --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.0/constraints-3.11.txt
     config:
       core:


### PR DESCRIPTION
The airflow-ext package is specified to be `main`, which is a branch that has changed since `plugins.meltano.yml` was authored. When I build today, I get constraints errors:

To Reproduce:
- Tested on Machine: Apple M2, OSX 14.2, Python v3.9.6, pip3 v23.3.1
- Run the command that Meltano will run underneath the covers:
```
$ pip3 install git+https://github.com/meltano/airflow-ext.git@main apache-airflow==2.7.0 psycopg2-binary --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.0/constraints-3.11.txt
<snip>

ERROR: Cannot install airflow-ext and apache-airflow==2.7.0 because these package versions have conflicting dependencies.
```

To fix, I've simply pinned `plugins.meltano.yml` to the commit on `airflow-ext`'s `main` branch at the time `plugins.meltano.yml` was last modified.

I note that the `airflow-ext` project has started to version their library with tags and releases, and using one of them is probably more appropriate. I'm unfortunately unable to figure out the best way to do this since I'm not very familiar with any of these packages, or python/pip in general. 